### PR TITLE
fix: Fix info for Viva Payment Services in Greek banks file

### DIFF
--- a/schwifty/bank_registry/manual_gr.json
+++ b/schwifty/bank_registry/manual_gr.json
@@ -163,8 +163,8 @@
         "primary": true,
         "name": "VIVA PAYMENT SERVICES SINGLE MEMBER S.A.",
         "short_name": "VIVA PAYMENT SERVICES S.A.",
-        "bank_code": "VPAY",
-        "bic": "VPAYGRAAXXX",
+        "bank_code": "701",
+        "bic": "VPAYGRAA",
         "country_code": "GR"
     },
     {


### PR DESCRIPTION
The banks added were retrieved based on the IBANs of users for which we failed to retrieve a BIC. The data were acquire from this [website](https://www.ibancalculator.com/).