### PR TITLE
fix(bank_registry): corrected manual_gr bank bic

### DIFF
--- a/schwifty/bank_registry/manual_gr.json
+++ b/schwifty/bank_registry/manual_gr.json
@@ -188,7 +188,7 @@
         "name": "COOPERATIVE BANK OF KARDITSA",
         "short_name": "COOPERATIVE BANK OF KARDITSA",
         "bank_code": "089",
-        "bic": "STKAGRA",
+        "bic": "STKAGRA1",
         "country_code": "GR"
     }
 ]


### PR DESCRIPTION
this bic now also checks out with [bic swift checker](https://wise.com/gb/swift-codes/bic-swift-code-checker) and [this resource](https://ibanapi.com/bank/24005/co-operative-bank-of-karditsa-l.l.c.) as well
![image](https://github.com/withplum/schwifty/assets/11624276/6ac6877b-8649-49da-ada5-8a0d8cf2e22f)
